### PR TITLE
Change properties to reflect client-side only.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-mod_version=1.0.3
+mod_version=1.0.4
 modid=shutupexperimentalsettings
 mc_version=1.16.5
 forge_version=36.0.13

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -18,4 +18,4 @@ Turns off the annoying experimental settings prompt before creating a world.
     mandatory=true
     versionRange="[36.0.4,)"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"


### PR DESCRIPTION
This fixes servers showing an incompatible mod list due to this client-side mod being set to required on both the server and client.
Fixes #4.